### PR TITLE
Improve IntelliSense popup items background color while using keyboar…

### DIFF
--- a/themes/new-ocean.json
+++ b/themes/new-ocean.json
@@ -33,7 +33,7 @@
     "editorRuler.foreground": "#ffffff16",
     "editorSuggestWidget.background": "#0d1a24",
     "editorSuggestWidget.border": "#6699cc",
-    "editorSuggestWidget.selectedBackground": "#0d1a24",
+    "editorSuggestWidget.selectedBackground": "#15262E",
     "editorWidget.background": "#15262E",
     "editorWidget.border": "#ffffff22",
     "editorWhitespace.foreground": "#65737e",


### PR DESCRIPTION
…d navigation

Navigating IntelliSense popup items using keyboard arrows uses the same background color as the default background color, and thus selected item is not visible. Fixed by changing editorSuggestWidget.selectedBackground to use a different color.


![issue](https://user-images.githubusercontent.com/6768125/80101730-dc827000-8582-11ea-8b9f-8ee67aa912c8.gif)

![fixed](https://user-images.githubusercontent.com/6768125/80101767-e906c880-8582-11ea-88fd-086c9f702d95.gif)
